### PR TITLE
feat: adding limits for getting all project (#4)

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -47,6 +47,7 @@ runs:
           gh project list \
             --owner ${{ inputs.project-owner }} \
             --format json \
+            --limit 1000 \
             --jq '.projects[] | select(.number == ${{ inputs.project-number }}) .id')
         gh project item-edit \
           --id ${{ inputs.item-id }} \


### PR DESCRIPTION
This pull request includes a change to the `action.yml` file. The change increases the limit of projects fetched from the GitHub API to 1000.

* [`action.yml`](diffhunk://#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6R50): Increased the limit for the GitHub API call to fetch projects to 1000.